### PR TITLE
docs: Added Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,18 @@
+name: 🐛 Bug
+description: Report an issue to help improve the project.
+labels: ['bug']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the question or issue, also include what you tried and what didn't work
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/doc_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/doc_issue.yaml
@@ -1,0 +1,19 @@
+name: 📄 Documentation issue
+description: Found an issue in the documentation? You can use this one!
+title: '[DOCS] <description>'
+labels: ['documentation']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the question or issue, also include what you tried and what didn't work
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Screenshots if applicable
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,19 @@
+name: 💡 General Feature Request
+description: Have a new idea/feature for Tarana? Please suggest!
+title: '[FEATURE] <description>'
+labels: ['feature']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the enhancement you propose, also include what you tried and what worked.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Screenshots if applicable
+    validations:
+      required: false


### PR DESCRIPTION
### Fix
 Closes #22

### Changes/Addition
- Add 3 issue templates
      - Bug
      - Doc
      - Feature

### Note 
Add these 3 labels if not present - `bug` `feature` `documentation` for auto labeling
